### PR TITLE
sourceMap support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ module.exports = CoffeeScriptCompiler = (function() {
     try {
       normalizedVendor = normalizeChecker((_ref = this.config) != null ? (_ref1 = _ref.conventions) != null ? _ref1.vendor : void 0 : void 0);
       bare = !normalizedVendor(path);
-      sourceMap = this.config.modules.addSourceUrls;
+      sourceMap = this.config.modules.sourceMaps;
       result = coffeescript.compile(data, {
         bare: bare,
         sourceMap: sourceMap,
@@ -43,7 +43,7 @@ module.exports = CoffeeScriptCompiler = (function() {
       });
       if (sourceMap) {
         return result = {
-          compiled: result.js,
+          code: result.js,
           map: result.v3SourceMap
         };
       }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,7 +21,7 @@ module.exports = class CoffeeScriptCompiler
     try
       normalizedVendor = normalizeChecker @config?.conventions?.vendor
       bare = not normalizedVendor path
-      sourceMap = @config.modules.addSourceUrls
+      sourceMap = @config.modules.sourceMaps
       result = coffeescript.compile data, {
         bare,
         sourceMap,
@@ -29,7 +29,7 @@ module.exports = class CoffeeScriptCompiler
       }
       if sourceMap
         result = {
-          compiled : result.js,
+          code : result.js,
           map : result.v3SourceMap
         }
     catch err


### PR DESCRIPTION
"addSourceUrls" config flag was previously used to add @sourceUrl instruction. Should we keep this config param for sourcemaps or add a different one? ("generateSourceMap" ...)
