### PR TITLE
Add line and column number to error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ module.exports = CoffeeScriptCompiler = (function() {
       return compiled = coffeescript.compile(data, options);
     } catch (_error) {
       err = _error;
-      return error = err;
+      return error = "" + err.location.first_line + ":" + err.location.first_column + " " + (err.toString());
     } finally {
       result = compiled && options.sourceMap ? {
         code: compiled.js,

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -32,7 +32,7 @@ module.exports = class CoffeeScriptCompiler
     try
       compiled = coffeescript.compile data, options
     catch err
-      error = err
+      error = "#{err.location.first_line}:#{err.location.first_column} #{err.toString()}"
     finally
       result = if compiled and options.sourceMap
         code: compiled.js, map: compiled.v3SourceMap


### PR DESCRIPTION
It's annoying that errors in console shows only what is wrong, but not tell exactly where error is in code. I've changed  one line to send other error object. Maybe it is not best solution, but it works. 

I've started using my fork version, but when I update brunch it doesn't work. So there are some changes in this plugin. 

I think is good idea to put this functionality to mainstream plugin. An coffestript error object contain also more information, so you could use it.
